### PR TITLE
KAN-29, 31, 32: Added shopping list feature

### DIFF
--- a/frontend/components/BackButton.js
+++ b/frontend/components/BackButton.js
@@ -1,11 +1,12 @@
 import React from "react";
-import { Pressable, StyleSheet, Dimensions } from "react-native";
+import { Pressable, StyleSheet, Dimensions, Text } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 
-export const BackButton = ( { onPress }) => {
+export const BackButton = ( { onPress, backText = '' }) => {
   return (
     <Pressable onPress={onPress} style={styles.backButton}>
       <Ionicons name="chevron-back-sharp" size={32} color="#EF2A39" />
+      <Text style={styles.backText}>{backText}</Text>
     </Pressable>
   );
 };
@@ -13,5 +14,13 @@ export const BackButton = ( { onPress }) => {
 const styles = StyleSheet.create({
   backButton: {
     alignSelf: "flex-start",
+    display: "flex",
+    flexDirection: "row",
+  },
+  backText: {
+    fontSize: 20,
+    color: "#EF2A39",
+    marginTop: 3,
+    fontWeight: "600",
   },
 });

--- a/frontend/components/CreateShoppingListPopup.js
+++ b/frontend/components/CreateShoppingListPopup.js
@@ -1,0 +1,176 @@
+import React, { useState, useContext } from "react";
+import { View, Text, StyleSheet, TextInput, Pressable, Modal } from "react-native";
+import Feather from "@expo/vector-icons/Feather";
+import { ShoppingList } from "../firebase/models/ShoppingList";
+import { HouseholdContext } from "../context/HouseholdContext";
+
+export const CreateShoppingListPopup = ({ onClose }) => {
+  const [shoppingListName, setShoppingListName] = useState("");
+  const [shoppingListCategory, setShoppingListCategory] = useState("None");
+  const [isShoppingListNameValid, setIsShoppingListNameValid] = useState(false);
+  const [shoppingListNameProvided, setShoppingListNameProvided] = useState(false);
+  const { householdId } = useContext(HouseholdContext);
+
+  const validateShoppingListName = () => {
+    if (shoppingListName.length === 0) {
+      setShoppingListNameProvided(false);
+      setIsShoppingListNameValid(false);
+    } else {
+        setShoppingListNameProvided(true);
+        if (shoppingListName.length < 5) {
+            setIsShoppingListNameValid(false);
+        } else {
+            setIsShoppingListNameValid(true);
+        }
+    }
+  };
+
+  const createNewShoppingList = async () => {
+    try {
+        const shoppingListToCreate = new ShoppingList(
+            householdId,
+            shoppingListCategory,
+            shoppingListName,
+            ""
+        );
+        const shoppingListDocRef = await ShoppingList.createShoppingList(
+            householdId,
+            shoppingListToCreate
+        );
+        console.log("Shopping List created with ID: ", shoppingListDocRef.id);
+        return shoppingListDocRef;
+    } catch (error) {
+        console.error("Error creating shopping list: ", error);
+    } finally {
+        setShoppingListName("");
+        onClose();
+    }
+  };
+
+  return (
+      <Modal
+        transparent={true}
+        animationType="fade"
+        onRequestClose={onClose}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContainer}>
+            <View style={styles.titleContainer}>
+              <Text style={styles.title}>Create Shopping List</Text>
+              <Pressable onPress={onClose}>
+                <Feather name="x-circle" size={28} color="red" />
+              </Pressable>
+            </View>
+
+            <View style={styles.inputContainer}>
+              <View style={styles.inputItem}>
+                <TextInput
+                  style={styles.input}
+                  name="shoppingListName"
+                  value={shoppingListName}
+                  placeholder="Shopping List Name"
+                  onChangeText={(shoppingListName) =>
+                    setShoppingListName(shoppingListName)
+                  }
+                  onBlur={validateShoppingListName}
+                ></TextInput>
+                {shoppingListNameProvided && !isShoppingListNameValid && (
+                  <Text style={styles.invalidInput}>
+                    Name must contain at least 5 characters.
+                  </Text>
+                )}
+              </View>
+
+              <View style={styles.inputItem}>
+                <TextInput
+                  style={styles.input}
+                  name="shoppingListCategory"
+                  value={shoppingListCategory === "None" ? "" : shoppingListCategory}
+                  placeholder="Shopping List Category"
+                  onChangeText={(shoppingListCategory) =>
+                    setShoppingListCategory(shoppingListCategory)
+                  }
+                ></TextInput>
+              </View>
+            </View>
+            <Pressable
+              style={[
+                styles.createButton,
+                isShoppingListNameValid ? null : styles.disabledButton,
+              ]}
+              disabled={!isShoppingListNameValid}
+              onPress={createNewShoppingList}
+            >
+              <Text style={styles.createButtonText}>Create</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  modalContainer: {
+    width: "85%",
+    backgroundColor: "white",
+    borderRadius: 10,
+    padding: 20,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4,
+    elevation: 5, // For Android shadow
+  },
+
+  titleContainer: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "700",
+    color: "#333",
+  },
+  inputContainer: {
+    marginBottom: 12,
+  },
+  inputItem: {
+    marginBottom: 8,
+  },
+  input: {
+    width: "100%",
+    padding: 10,
+    borderWidth: 1,
+    borderColor: "#ccc",
+    borderRadius: 5,
+    fontSize: 16,
+    backgroundColor: "#f9f9f9",
+  },
+  invalidInput: {
+    color: "#EF2A39",
+    marginTop: 5,
+    fontSize: 14,
+  },
+  createButton: {
+    backgroundColor: "#EF2A39",
+    padding: 12,
+    borderRadius: 5,
+    alignItems: "center",
+  },
+  createButtonText: {
+    color: "white",
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  disabledButton: {
+    backgroundColor: "#ccc",
+  },
+});

--- a/frontend/components/HouseholdCard.js
+++ b/frontend/components/HouseholdCard.js
@@ -14,7 +14,7 @@ export const HouseholdCard = ({ householdName, numberOfMembers, householdId }) =
         <Entypo name="home" size={32} color="#FF4C4C" />
         <View style={styles.textContainer}>
           <Text style={styles.householdName}>{householdName}</Text>
-          <Text style={styles.memberCount}>{numberOfMembers} Members</Text>
+          <Text style={styles.memberCount}>{numberOfMembers + (numberOfMembers === 1 ? ' Member' : ' Members')}</Text>
         </View>
       </View>
     </Pressable>
@@ -40,6 +40,7 @@ const styles = StyleSheet.create({
   },
   textContainer: {
     flex: 1,
+    marginLeft: 10,
   },
   householdName: {
     fontSize: 18,

--- a/frontend/components/ListCard.js
+++ b/frontend/components/ListCard.js
@@ -1,0 +1,60 @@
+import React from "react";
+import { View, Text, StyleSheet, Pressable } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+
+export const ListCard = ({
+  shoppingListName,
+  shoppingListId,
+  shoppingListCategory,
+}) => {
+  const navigation = useNavigation();
+
+  return (
+    <Pressable
+      style={styles.cardContainer}
+      onPress={() =>
+        navigation.navigate("ShoppingListContent", {
+          shoppingListName,
+          shoppingListId,
+          shoppingListCategory
+        })
+      }
+    >
+      <View style={styles.cardContent}>
+          <Text style={styles.listName}>{shoppingListName}</Text>
+          <Text style={styles.category}>{shoppingListCategory}</Text>
+      </View>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  cardContainer: {
+    backgroundColor: "#fff",
+    borderRadius: 8,
+    padding: 16,
+    marginVertical: 4,
+    marginHorizontal: 16,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 4,
+  },
+  cardContent: {
+    flexDirection: "column",
+  },
+  listName: {
+    fontSize: 18,
+    fontWeight: "bold",
+    color: "#333",
+  },
+  category: {
+    fontSize: 14,
+    color: "#666",
+    marginTop: 4,
+  },
+});

--- a/frontend/components/RequestedItemCard.js
+++ b/frontend/components/RequestedItemCard.js
@@ -1,0 +1,82 @@
+import React, { useContext, useState } from "react";
+import { CheckBox } from "react-native-elements";
+import { View, Text, StyleSheet } from "react-native";
+import { RequestedItem } from "../firebase/models/RequestedItem";
+import { HouseholdContext } from "../context/HouseholdContext";
+
+export const RequestedItemCard = ({ 
+    shoppingListId,
+    requestedItemId,
+    requestedItemName, 
+    requestedItemQuantity,
+    requestedItemBrand,
+    isrequestedItemFulfilled
+}) => {
+    const { householdId } = useContext(HouseholdContext);
+    const [isChecked, setIsChecked] = useState(isrequestedItemFulfilled);
+
+    const handleCheckboxToggle = async () => {
+        try {
+            const requestedItem = await RequestedItem.getRequestedItem(
+                householdId,
+                shoppingListId,
+                requestedItemId
+            );
+            requestedItem.requestFullfilled = !isChecked;
+            await RequestedItem.updateRequestedItem(
+                householdId,
+                shoppingListId,
+                requestedItemId,
+                requestedItem
+            );
+            setIsChecked(!isChecked);
+        } catch (error) {
+            console.error("Error updating shopping list item status: ", error);
+        }
+    }
+    return (
+        <View style={styles.container}>
+            <CheckBox
+                checked={isChecked}
+                onPress={handleCheckboxToggle}
+                containerStyle={styles.checkboxContainer}
+                checkedColor="#EF2A39"
+            />
+            <View style={styles.textContainer}>
+                <Text style={styles.requestedItemName}>{requestedItemName}</Text>
+                <Text style={styles.requestedItemBrand}>{requestedItemBrand}</Text>
+                <Text style={styles.requestedItemQuantity}>Quantity: {requestedItemQuantity}</Text>
+            </View>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flexDirection: "row",
+        alignItems: "center",
+        padding: 10,
+        borderBottomWidth: 1,
+        borderBottomColor: "#E0E0E0",
+    },
+    textContainer: {
+        flex: 1,
+        marginLeft: 10,
+    },
+    requestedItemName: {
+        fontSize: 18,
+        fontWeight: "bold",
+    },
+    requestedItemBrand: {
+        fontSize: 16,
+    },
+    requestedItemQuantity: {
+        fontSize: 16,
+    },
+    checkboxContainer: {
+        // margin: 0,
+        // padding: 0,
+        backgroundColor: "transparent",
+        // borderWidth: 0,
+      }
+});

--- a/frontend/firebase/models/RequestedItem.js
+++ b/frontend/firebase/models/RequestedItem.js
@@ -18,8 +18,8 @@ class RequestedItem {
     itemRequester,
     name,
     brand,
-    categories,
-    allergens,
+    categories = [],
+    allergens = [],
     quantityRequested,
     requestFullfilled,
     dateRequested,
@@ -56,13 +56,15 @@ class RequestedItem {
         const requestedItem = new RequestedItem(
           householdId,
           shoppingListId,
-          snapshot.data().category,
-          snapshot.data().dateRequested,
           snapshot.data().itemRequester,
-          snapshot.data().location,
           snapshot.data().name,
+          snapshot.data().brand,  
+          snapshot.data().categories,
+          snapshot.data().allergens,
           snapshot.data().quantityRequested,
           snapshot.data().requestFullfilled,
+          snapshot.data().dateRequested,
+          snapshot.data().productUpc,
           snapshot.id
         );
         return requestedItem;
@@ -92,14 +94,16 @@ class RequestedItem {
             new RequestedItem(
               householdId,
               shoppingListId,
-              doc.data().category,
-              doc.data().dateRequested,
-              doc.data().itemRequester,
-              doc.data().location,
-              doc.data().name,
-              doc.data().quantityRequested,
-              doc.data().requestFullfilled,
-              doc.id
+              snapshot.data().itemRequester,
+              snapshot.data().name,
+              snapshot.data().brand,  
+              snapshot.data().categories,
+              snapshot.data().allergens,
+              snapshot.data().quantityRequested,
+              snapshot.data().requestFullfilled,
+              snapshot.data().dateRequested,
+              snapshot.data().productUpc,
+              snapshot.id
             )
         );
         return requestedItems;
@@ -165,10 +169,9 @@ class RequestedItem {
         {
           householdId: householdId,
           shoppingListId: shoppingListId,
-          category: requestedItem.category,
+          categories: requestedItem.categories,
           dateRequested: requestedItem.dateRequested,
           itemRequester: requestedItem.itemRequester,
-          location: requestedItem.location,
           name: requestedItem.name,
           quantityRequested: requestedItem.quantityRequested,
           requestFullfilled: requestedItem.requestFullfilled,

--- a/frontend/firebase/models/ShoppingList.js
+++ b/frontend/firebase/models/ShoppingList.js
@@ -33,7 +33,8 @@ class ShoppingList {
                 const shoppingLists = snapshot.docs.map(doc => new ShoppingList(householdId, doc.data().category, doc.data().name, doc.id));
                 return shoppingLists;
             } else {
-                throw new Error('No shopping lists found');
+                // throw new Error('No shopping lists found');
+                return [];
             }
         } catch (error) {
             console.error('Error getting shopping lists:', error);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "react-dom": "18.3.1",
     "react-native": "0.76.5",
     "react-native-dropdown-select-list": "2.0.5",
+    "react-native-elements": "^3.4.3",
     "react-native-gesture-handler": "2.20.2",
     "react-native-modal": "^13.0.1",
     "react-native-reanimated": "3.16.1",

--- a/frontend/routes/SelectedHousehold.js
+++ b/frontend/routes/SelectedHousehold.js
@@ -1,6 +1,6 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
-import { ShoppingList } from "../screens/ShoppingList";
+import { ShoppingListStack } from "./ShoppingListStack";
 import { Ionicons } from "@expo/vector-icons";
 import { Text, StyleSheet } from "react-native";
 import { Pantry } from "../screens/Pantry";
@@ -65,7 +65,7 @@ export const SelectedHousehold = ({ route }) => {
       >
         <Tab.Screen
           name="Lists"
-          component={ShoppingList}
+          component={ShoppingListStack}
           initialParams={{
             householdId: householdId,
             householdName: householdName,

--- a/frontend/routes/ShoppingListStack.js
+++ b/frontend/routes/ShoppingListStack.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { createStackNavigator } from "@react-navigation/stack";
+import { ShoppingList } from "../screens/ShoppingList";
+import { ShoppingListContent } from "../screens/ShoppingListContent";
+// import { ScanItem } from "../screens/ScanItem";
+
+const Stack = createStackNavigator();
+
+export const ShoppingListStack = ({ route }) => {
+    const { shoppingListName, shoppingListId, shoppingListCategory } = route.params;
+    return (
+        <Stack.Navigator
+            initialRouteName="ShoppingList"
+            screenOptions={{ headerShown: false }}
+        >
+            <Stack.Screen 
+                name="ShoppingList" 
+                component={ShoppingList}
+            />
+            <Stack.Screen 
+                name="ShoppingListContent" 
+                component={ShoppingListContent} 
+                initialParams={{
+                    shoppingListName: shoppingListName,
+                    shoppingListId: shoppingListId,
+                    shoppingListCategory: shoppingListCategory
+                }}
+            />
+            {/* <Stack.Screen
+                name="ScanItem"
+                component={ScanItem}
+            /> */}
+        </Stack.Navigator>
+    );
+};

--- a/frontend/screens/Home.js
+++ b/frontend/screens/Home.js
@@ -104,6 +104,7 @@ const styles = StyleSheet.create({
     textAlign: "left",
     marginTop: 20,
     marginBottom: 10,
+    marginLeft: 20,
     textShadowColor: "rgba(0, 0, 0, 0.1)", // Subtle shadow
     textShadowOffset: { width: 1, height: 1 },
     textShadowRadius: 2,

--- a/frontend/screens/ShoppingList.js
+++ b/frontend/screens/ShoppingList.js
@@ -1,16 +1,139 @@
 import React from "react";
-import { Text, View } from "react-native";
-import { useContext } from "react";
+import { Text, View, StyleSheet, FlatList } from "react-native";
+import { useContext, useEffect, useState } from "react";
 import { HouseholdContext } from "../context/HouseholdContext";
-
+// import { BackButton } from "../components/BackButton";
+import { AddButton } from "../components/AddButton";
+import { ListCard } from "../components/ListCard";
+import { CreateShoppingListPopup } from "../components/CreateShoppingListPopup";
+import { MaterialIcons } from "@expo/vector-icons";
+import { collection, onSnapshot, query } from "firebase/firestore";
+import { firestore } from "../firebase/config";
+// import { useNavigation } from "@react-navigation/native";
+ 
 export const ShoppingList = () => {
   const { householdId, householdName } = useContext(HouseholdContext);
+  const [hasShoppingLists, setHasShoppingLists] = useState(true);
+  const [showCreateShoppingListForm, setShowCreateShoppingListForm] = useState(false);
+  const [shoppingLists, setShoppingLists] = useState([]);
+  // const navigation = useNavigation();
+
+  const openCreateShoppingListForm = () => {
+    setShowCreateShoppingListForm(true);
+  };
+
+  const closeCreateShoppingListForm = () => {
+    setShowCreateShoppingListForm(false);
+  };
+
+  useEffect(() => {
+    const shoppingListsCollection = collection(firestore, `households/${householdId}/shopping_list`);
+    const q = query(shoppingListsCollection);
+    const unsubscribe = onSnapshot(q, (snapshot) => {
+      const shoppingLists = snapshot.docs.map((doc) => ({
+        id: doc.id,
+        ...doc.data(),
+      }));
+      setShoppingLists(shoppingLists);
+      setHasShoppingLists(shoppingLists.length > 0);
+    });
+
+    return () => unsubscribe();
+  }, [householdId]);
 
   return (
-    <View>
-      <Text> Shopping List Screen </Text>
-      <Text> Household Name: {householdName} </Text>
-      <Text> Household ID: {householdId} </Text>
+    <View style={styles.container}>
+      {/* <View style={styles.backContainer}>
+        <BackButton onPress={() => navigation.goBack()} backText="Home"/>
+      </View> */}
+      <Text style={styles.upperTitle}>{householdName}</Text>
+      <Text style={styles.lowerTitle}>Shopping Lists</Text>
+      {/* FlatList of Shopping Lists */}
+      <View>
+        {hasShoppingLists ? (
+          <FlatList
+            data={shoppingLists}
+            renderItem={({ item }) => (
+              <ListCard
+                shoppingListName={item.name}
+                shoppingListId={item.id}
+                shoppingListCategory={item.category}
+              />
+            )}
+            keyExtractor={(item) => item.id}
+          />
+        ) : (
+          <View style={styles.noShoppingLists}>
+            <MaterialIcons name="shopping-cart" size={64} color="#EF2A39" style={styles.noShoppingListsIcon} />
+            <Text style={styles.noShoppingListsText}>No shopping lists found for {householdName}.</Text>
+            <Text style={styles.noShoppingListsText}>Create one now to get started!</Text>
+          </View>
+        )}
+      </View>
+      
+      {/* Floating Add Button to create new list */}
+      <View style={styles.addButtonContainer}>
+        <AddButton
+          color="#EF2A39"
+          size="56"
+          onPress={openCreateShoppingListForm}
+        />
+      </View>
+      {/* Bottom Sheet to create new shopping list */}
+      {showCreateShoppingListForm && (
+        <View style={styles.bottomFormOverlay}>
+          <CreateShoppingListPopup
+            onClose={closeCreateShoppingListForm}
+          />
+        </View>
+      )}
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "white",
+  },
+  upperTitle: {
+    fontSize: 20,
+    marginHorizontal: 16,
+    marginTop: 8,
+    fontWeight: "800",
+    color: "#999",
+  },
+  lowerTitle: {
+    fontSize: 28,
+    margin: 16,
+    marginTop: 0,
+    fontWeight: "800",
+  },
+  addButtonContainer: {
+    position: "absolute",
+    bottom: 110,
+    right: 25,
+  },
+  backContainer: {
+    marginTop: 5,
+  },
+  noShoppingLists: {
+    marginTop: 100,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  noShoppingListsIcon: {
+    marginBottom: 10,
+  },
+  noShoppingListsText: {
+    fontSize: 16,
+    fontWeight: "600",
+    marginTop: 5,
+    textAlign: "center",
+  },
+  bottomFormOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 100,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+  },
+});

--- a/frontend/screens/ShoppingListContent.js
+++ b/frontend/screens/ShoppingListContent.js
@@ -1,0 +1,128 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { View, Text, StyleSheet, FlatList, Pressable } from 'react-native';
+import { HouseholdContext } from "../context/HouseholdContext";
+import { BackButton } from "../components/BackButton";
+import { RequestedItemCard } from "../components/RequestedItemCard";
+import { collection, onSnapshot, query } from "firebase/firestore";
+import { firestore } from "../firebase/config";
+import { useNavigation } from "@react-navigation/native";
+import { AddButton } from '../components/AddButton';
+
+export const ShoppingListContent = ({ route }) => {
+    const { householdId } = useContext(HouseholdContext);
+    const { shoppingListName, shoppingListId, shoppingListCategory } = route.params;
+    const [shoppingListItems, setShoppingListItems] = useState([]);
+    const [hasShoppingListItems, setHasShoppingListItems] = useState(false);
+    const [numItems, setNumItems] = useState(0);
+    const [numItemsFulfilled, setNumItemsFulfilled] = useState(0);
+    const navigation = useNavigation();
+
+    useEffect(() => {
+        const shoppingListItemsCollection = collection(firestore, `households/${householdId}/shopping_list/${shoppingListId}/requested_items`);
+        const q = query(shoppingListItemsCollection);
+        const unsubscribe = onSnapshot(q, (snapshot) => {
+            const shoppingListItems = snapshot.docs.map((doc) => ({
+                id: doc.id,
+                ...doc.data(),
+            }));
+            setShoppingListItems(shoppingListItems);
+            setHasShoppingListItems(shoppingListItems.length > 0);
+        })
+        return () => unsubscribe();
+    }, [shoppingListId]);
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.backContainer}>
+                <BackButton onPress={() => navigation.goBack()} backText="Shopping Lists"/>
+            </View>
+            <View style={styles.header}>
+                <Text style={styles.listName}>{shoppingListName}</Text>
+                {shoppingListCategory !== "None" && 
+                    <View style={styles.listCategoryTag}>
+                        <Text style={styles.listCategoryTagText}>{shoppingListCategory}</Text>
+                    </View> 
+                }
+                <View style={styles.addButtonContainer}>
+                    <AddButton 
+                    size={28}
+                    color={"#EF2A39"} 
+                    // onPress={() => navigation.navigate("ScanItem")}
+                    />
+                </View>
+                
+            </View>
+            
+            {/* FlatList of Shopping List Items */}
+            <View>
+                {hasShoppingListItems ? (
+                    <FlatList
+                    data={shoppingListItems}
+                    renderItem={({ item }) => (
+                        <RequestedItemCard
+                            shoppingListId={shoppingListId}
+                            requestedItemId={item.id}
+                            requestedItemName={item.name}
+                            requestedItemQuantity={item.quantityRequested}
+                            requestedItemBrand={item.brand}
+                            isrequestedItemFulfilled={item.requestFullfilled}
+                        />
+                    )}
+                    keyExtractor={(item) => item.id}
+                    />
+                ) : (
+                    <View style={styles.noShoppingListItems}>
+                        <Text style={styles.noShoppingListItemsText}>
+                            No items found in this shopping list.
+                        </Text>
+                    </View>
+                )}
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: "white",
+    },
+    backContainer: {
+        marginTop: 5,
+    },
+    header: {
+        flexDirection: "row",
+        alignItems: "center",
+        margin: 12,
+        marginTop: 8,
+    },
+    listName: {
+        fontSize: 28,
+        fontWeight: "bold",
+        marginRight: 12,
+    },
+    listCategoryTag: {
+        backgroundColor: "#EF2A39",
+        borderRadius: 8,
+        paddingVertical: 4,
+        paddingHorizontal: 8,
+    },
+    listCategoryTagText: {
+        color: "#fff",
+        fontSize: 14,
+        fontWeight: "bold",
+    },
+    noShoppingListItems: {
+        marginTop: 200,
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    noShoppingListItemsText: {
+        fontSize: 16,
+        textAlign: "center",
+    },
+    addButtonContainer: {
+        position: "absolute",
+        right: 5,
+    },
+});


### PR DESCRIPTION
Added the functionality to create and view shopping lists and their associated items:
- Created ShoppingList screen so that when a household is selected, it routes to that screen to display the list of corresponding ShoppingListCards (note: styling to be improved; currently only shows name and category, would like to add item count as well)
- Created CreateShoppingListPopup (modelled after CreateHouseholdPopup) to create a shopping list with a name and category (I left category as optional for now)
- Created ShoppingListContent screen so that shopping list items can be viewed upon clicking on a shopping list, and the items can be checked or unchecked (note: still need to fix styling for this! especially the RequestedItemCards and would like to allow the user to click on the item and see relevant info about it)

Also, added the option to put text for back button since it felt intuitive to have a back button when I was testing out the shopping lists BUT doesn't go with menu button in our UI so may remove later?

Images:
Shopping Lists Page
<img width="364" alt="Screenshot 2025-01-26 at 11 47 03 PM" src="https://github.com/user-attachments/assets/3306a9ba-9fd7-41ff-969c-8dc9c5f31004" />

Add Shopping List Popup
<img width="367" alt="Screenshot 2025-01-26 at 11 48 25 PM" src="https://github.com/user-attachments/assets/bf4c8019-a3d7-4b46-8957-2e3fde255b1c" />

Shopping List Content Page
<img width="362" alt="Screenshot 2025-01-26 at 11 48 57 PM" src="https://github.com/user-attachments/assets/204053ef-0958-4aa8-8f45-443592f82292" />
